### PR TITLE
Add support for comparing body of the request alongside default compare

### DIFF
--- a/cassette.go
+++ b/cassette.go
@@ -1,6 +1,7 @@
 package mixtape
 
 import (
+	"bytes"
 	"crypto/tls"
 	"encoding/json"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 )
@@ -20,6 +22,18 @@ type Cassette struct {
 	Comparer           func(*http.Request, *Request) bool `json:"-"`
 	nextRecordingIndex int
 	sync.RWMutex
+}
+
+func (c *Cassette) Equal(other *Cassette) bool {
+	if len(c.Songs) != len(other.Songs) {
+		return false
+	}
+	for i, song := range c.Songs {
+		if !song.Equal(other.Songs[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *Cassette) Save() error {
@@ -46,17 +60,49 @@ func (c *Cassette) Save() error {
 	if err != nil {
 		return err
 	}
-	f, err := os.Create(c.FilePath)
+	_, err = os.Stat(c.FilePath)
 	if err != nil {
-		return err
+		if os.IsNotExist(err) {
+			f, err := os.Create(c.FilePath)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			_, err = f.Write(data)
+			return err
+		}
 	}
-	defer f.Close()
-	_, err = f.Write(data)
-	return err
+
+	oldCassette, cErr := Load(c.Name)
+	if cErr != nil {
+		return cErr
+	}
+	if oldCassette.Equal(c) {
+		return nil
+	}
+	return os.WriteFile(c.FilePath, data, 0644)
 }
 
 func DefaultCompareFunc(r *http.Request, recording *Request) bool {
 	return r.Method == recording.Method && r.URL.String() == recording.URL
+}
+
+func CompareFuncWithBody(r *http.Request, recording *Request) bool {
+	if !DefaultCompareFunc(r, recording) {
+		return false
+	}
+	if r.Body == nil && recording.Body == "" {
+		return true
+	}
+	if r.Body == nil {
+		return false
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return false
+	}
+	r.Body = io.NopCloser(bytes.NewBuffer(body))
+	return string(body) == recording.Body
 }
 
 func New(name string) *Cassette {
@@ -94,6 +140,19 @@ type Song struct {
 	ID       int       `json:"id"`
 	Request  *Request  `json:"request"`
 	Response *Response `json:"response"`
+}
+
+func (s *Song) Equal(other *Song) bool {
+	if s.ID != other.ID {
+		return false
+	}
+	if !s.Request.Equal(other.Request) {
+		return false
+	}
+	if !s.Response.Equal(other.Response) {
+		return false
+	}
+	return true
 }
 
 func NewSong(req *http.Request, resp *http.Response) (*Song, error) {
@@ -134,6 +193,64 @@ type Request struct {
 	TLS              *tls.ConnectionState
 }
 
+func (r *Request) Equal(other *Request) bool {
+	if r.Method != other.Method {
+		return false
+	}
+	if r.URL != other.URL {
+		return false
+	}
+	if r.Proto != other.Proto {
+		return false
+	}
+	if r.ProtoMajor != other.ProtoMajor {
+		return false
+	}
+	if r.ProtoMinor != other.ProtoMinor {
+		return false
+	}
+	if !reflect.DeepEqual(r.Header, other.Header) {
+		return false
+	}
+	if r.Body != other.Body {
+		return false
+	}
+	if r.ContentLength != other.ContentLength {
+		return false
+	}
+	if !reflect.DeepEqual(r.TransferEncoding, other.TransferEncoding) {
+		return false
+	}
+	if r.Close != other.Close {
+		return false
+	}
+	if r.Host != other.Host {
+		return false
+	}
+	if !reflect.DeepEqual(r.Form, other.Form) {
+		return false
+	}
+	if !reflect.DeepEqual(r.PostForm, other.PostForm) {
+		return false
+	}
+	if !reflect.DeepEqual(r.MultipartForm, other.MultipartForm) {
+		return false
+	}
+	if !reflect.DeepEqual(r.Trailer, other.Trailer) {
+		return false
+	}
+	if r.RemoteAddr != other.RemoteAddr {
+		return false
+	}
+	if r.RequestURI != other.RequestURI {
+		return false
+	}
+	if !reflect.DeepEqual(r.TLS, other.TLS) {
+		return false
+	}
+	return true
+}
+
 // Response represents the response from a server which can be saved in json/yaml format.
 // Majority of the properties in this struct could be classed as members of http.Response object
 // however, there is a subtle distinction between http.Response and this Response. Mostly
@@ -151,6 +268,48 @@ type Response struct {
 	TransferEncoding []string
 	Close            bool
 	Trailer          http.Header
+}
+
+func (r *Response) Equal(other *Response) bool {
+	if r.Status != other.Status {
+		return false
+	}
+	if r.StatusCode != other.StatusCode {
+		return false
+	}
+	if r.Proto != other.Proto {
+		return false
+	}
+	if r.ProtoMajor != other.ProtoMajor {
+		return false
+	}
+	if r.ProtoMinor != other.ProtoMinor {
+		return false
+	}
+	for k, v := range r.Header {
+		if k == "Date" {
+			continue
+		}
+		if !reflect.DeepEqual(v, other.Header[k]) {
+			return false
+		}
+	}
+	if r.Body != other.Body {
+		return false
+	}
+	if r.ContentLength != other.ContentLength {
+		return false
+	}
+	if !reflect.DeepEqual(r.TransferEncoding, other.TransferEncoding) {
+		return false
+	}
+	if r.Close != other.Close {
+		return false
+	}
+	if !reflect.DeepEqual(r.Trailer, other.Trailer) {
+		return false
+	}
+	return true
 }
 
 func (r *Song) HTTPRequest() (*http.Request, error) {

--- a/player/player_test.go
+++ b/player/player_test.go
@@ -1,11 +1,12 @@
 package player_test
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -22,9 +23,15 @@ func ExampleRecord() {
 		Transport: player,
 	}
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
+	l, err := net.Listen("tcp", "127.0.0.1:52120")
+	if err != nil {
+		panic(err)
+	}
+	server.Listener = l
+	server.Start()
 	defer server.Close()
 	resp, err := c.Get(server.URL)
 	if err != nil {
@@ -36,10 +43,6 @@ func ExampleRecord() {
 		panic(err)
 	}
 	fmt.Println(string(data))
-	err = os.Remove(cassette.FilePath)
-	if err != nil {
-		panic(err)
-	}
 	// Output:
 }
 
@@ -71,18 +74,82 @@ func TestRecord(t *testing.T) {
 	c := &http.Client{
 		Transport: player,
 	}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	testServerURL := "127.0.0.1:52119"
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
+	l, err := net.Listen("tcp", testServerURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server.Listener = l
+	server.Start()
 	defer server.Close()
 	resp, err := c.Get(server.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer resp.Body.Close()
-	err = os.Remove(cassette.FilePath)
+}
+
+func TestRecordWithBody(t *testing.T) {
+	filePath := filepath.Join("testdata", "test_record_with_body") // this must be without the .json extension
+	cassette := mixtape.New(filePath)
+	cassette.Comparer = mixtape.CompareFuncWithBody // check the body as well
+	songPlayer := player.New(cassette, player.Record, http.DefaultTransport)
+	defer cassette.Save()
+	c := &http.Client{
+		Transport: songPlayer,
+	}
+	data := bytes.Buffer{}
+	data.WriteString("Hello, World!")
+	testServerURL := "127.0.0.1:52118"
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	l, _ := net.Listen("tcp", testServerURL)
+	server.Listener = l
+	server.Start()
+	defer server.Close()
+	req, err := http.NewRequest(http.MethodPost, server.URL, &data)
 	if err != nil {
 		t.Fatal(err)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+}
+
+func TestReplayWithBody(t *testing.T) {
+	filePath := filepath.Join("testdata", "test_replay_with_body") // this must be without the .json extension
+	cassette, err := mixtape.Load(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cassette.Comparer = mixtape.CompareFuncWithBody // check the body as well
+	player := player.New(cassette, player.Record, http.DefaultTransport)
+	c := &http.Client{
+		Transport: player,
+	}
+	data := bytes.Buffer{}
+	data.WriteString("Hello, World!")
+	req, err := http.NewRequest(http.MethodPost, "http://example.com/something-here", &data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(respBody) != "Something here" {
+		t.Errorf("expected: %s, got: %s", "Something here", string(respBody))
 	}
 }
 

--- a/player/testdata/test_record.json
+++ b/player/testdata/test_record.json
@@ -4,7 +4,7 @@
       "id": 0,
       "request": {
         "Method": "GET",
-        "URL": "http://127.0.0.1:52116",
+        "URL": "http://127.0.0.1:52119",
         "Proto": "HTTP/1.1",
         "ProtoMajor": 1,
         "ProtoMinor": 1,
@@ -13,7 +13,7 @@
         "ContentLength": 0,
         "TransferEncoding": null,
         "Close": false,
-        "Host": "127.0.0.1:52116",
+        "Host": "127.0.0.1:52119",
         "Form": null,
         "PostForm": null,
         "MultipartForm": null,
@@ -33,7 +33,7 @@
             "0"
           ],
           "Date": [
-            "Tue, 21 Feb 2023 02:50:47 GMT"
+            "Wed, 22 Feb 2023 22:50:33 GMT"
           ]
         },
         "Body": "",

--- a/player/testdata/test_record_with_body.json
+++ b/player/testdata/test_record_with_body.json
@@ -3,17 +3,17 @@
     {
       "id": 0,
       "request": {
-        "Method": "GET",
-        "URL": "http://127.0.0.1:52120",
+        "Method": "POST",
+        "URL": "http://127.0.0.1:52118",
         "Proto": "HTTP/1.1",
         "ProtoMajor": 1,
         "ProtoMinor": 1,
         "Header": {},
-        "Body": "",
-        "ContentLength": 0,
+        "Body": "Hello, World!",
+        "ContentLength": 13,
         "TransferEncoding": null,
         "Close": false,
-        "Host": "127.0.0.1:52120",
+        "Host": "127.0.0.1:52118",
         "Form": null,
         "PostForm": null,
         "MultipartForm": null,
@@ -33,7 +33,7 @@
             "0"
           ],
           "Date": [
-            "Wed, 22 Feb 2023 22:47:03 GMT"
+            "Wed, 22 Feb 2023 22:50:49 GMT"
           ]
         },
         "Body": "",

--- a/player/testdata/test_replay_with_body.json
+++ b/player/testdata/test_replay_with_body.json
@@ -3,17 +3,17 @@
     {
       "id": 0,
       "request": {
-        "Method": "GET",
-        "URL": "http://127.0.0.1:52120",
+        "Method": "POST",
+        "URL": "http://example.com/something-here",
         "Proto": "HTTP/1.1",
         "ProtoMajor": 1,
         "ProtoMinor": 1,
         "Header": {},
-        "Body": "",
-        "ContentLength": 0,
+        "Body": "Hello, World!",
+        "ContentLength": 13,
         "TransferEncoding": null,
         "Close": false,
-        "Host": "127.0.0.1:52120",
+        "Host": "127.0.0.1:59401",
         "Form": null,
         "PostForm": null,
         "MultipartForm": null,
@@ -33,10 +33,10 @@
             "0"
           ],
           "Date": [
-            "Wed, 22 Feb 2023 22:47:03 GMT"
+            "Wed, 22 Feb 2023 21:44:37 GMT"
           ]
         },
-        "Body": "",
+        "Body": "Something here",
         "ContentLength": 0,
         "TransferEncoding": null,
         "Close": false,


### PR DESCRIPTION
In this PR we add support for comparing the request body alongside the default compare which only checked the request method as well as the URL string. We also updated the tests to make them determinitic so that if there is no change in the request response cycle (except for the 'Date' header) the cassette.Save() option doesn't overwrite the existing cassette (this was a design decision we went with but if there is any problems we can easily change this behaviour).